### PR TITLE
MD-Basic support.

### DIFF
--- a/WeeGUI.h
+++ b/WeeGUI.h
@@ -1,0 +1,68 @@
+' ============================================================
+'
+' WeeGUI.h	MD Basic WeeGUI support.
+' https://github.com/blondie7575/WeeGUI
+' http://www.morgandavis.net/blog/2009/08/09/md-basic/
+' ============================================================
+
+#pragma	once
+#reserve WINDW, CHKBX, BUTTN, KILL, SEL, PDACT, FOC, FOCN, FOCP
+#reserve ACT, PNT, PNTA, ERASE, WIPE, TITLE, STACT, PROG, SETV
+#reserve CURSR
+#reserve SCR, SCRBY
+#reserve HOME, DESK, PLOT, PRINT, DRAW, FILL
+#reserve MOUSE, GET
+#reserve EXIT
+
+' View Styles
+#define FramelessView 0
+#define PlainView 1
+#define DecoratedView 2
+
+' View Routines
+#define WGCreateView &WINDW
+#define WGCreateCheckbox &CHKBX
+'#define WGCreateButton &BUTTN
+#define WGCreateButton(p1,p2,p3,p4,p5,p6) &BUTTN(p1,p2,p3,p4,gosub p5,p6)
+#define WGDeleteView &KILL
+#define WGSelectView &SEL
+#define WGPendingViewAction &PDACT
+#define WGViewFocus &FOC
+#define WGViewFocusNext &FOCN
+#define WGViewFocusPrev &FOCP
+#define WGViewFocusAction &ACT
+#define WGPaintView &PNT
+#define WGViewPaintAll &PNTA
+#define WGEraseViewContents &ERASE
+#define WGEraseView &WIPE
+#define WGViewSetTitle &TITLE
+'#define WGViewSetAction &STACT
+#define WGViewSetAction(p1) &STACT(gosub p1)
+#define WGCreateProgress &PROG
+#define WGSetValue &SETV
+
+' Cursor Routines
+#define WGSetCursor &CURSR
+
+' Scrolling Routines
+#define WGScroll &SCR
+#define WGScrollBy &SCRBY
+#define WGScrollByX(x) WGScrollBy(x, 0)
+#define WGScrollByY(y) WGScrollBy(0, y)
+
+' Drawing Routines
+#define WGClearScreen &HOME
+#define WGDesktop &DESK
+#define WGPlot &PLOT
+#define WGPrint &PRINT
+#define WGStrokeRect &DRAW
+#define WGFillRect &FILL
+
+' Mouse & Keyboard Routines
+#define WGEnableMouse &MOUSE(1)
+#define WGDisableMouse &MOUSE(0)
+#define WGMouse &MOUSE
+#define WGGet &GET
+
+' Miscellanous
+#define WGExit &EXIT

--- a/WeeGUI.h
+++ b/WeeGUI.h
@@ -22,10 +22,13 @@
 ' View Routines
 #define WGCreateView &WINDW
 #define WGCreateCheckbox &CHKBX
+#define WGCreateRadio &RADIO
+#define WGCreateProgress &PROG
 '#define WGCreateButton &BUTTN
 #define WGCreateButton(p1,p2,p3,p4,p5,p6) &BUTTN(p1,p2,p3,p4,gosub p5,p6)
 #define WGDeleteView &KILL
 #define WGSelectView &SEL
+#define WGGetSel &GTSEL
 #define WGPendingViewAction &PDACT
 #define WGViewFocus &FOC
 #define WGViewFocusNext &FOCN
@@ -33,13 +36,13 @@
 #define WGViewFocusAction &ACT
 #define WGPaintView &PNT
 #define WGViewPaintAll &PNTA
-#define WGEraseViewContents &ERASE
-#define WGEraseView &WIPE
+#define WGEraseViewContents &ERASE(0)
+#define WGEraseView &ERASE(1)
 #define WGViewSetTitle &TITLE
 '#define WGViewSetAction &STACT
 #define WGViewSetAction(p1) &STACT(gosub p1)
-#define WGCreateProgress &PROG
-#define WGSetValue &SETV
+#define WGSetState &SETV
+#define WGViewSetRawTitle &STRW
 
 ' Cursor Routines
 #define WGSetCursor &CURSR
@@ -47,12 +50,13 @@
 ' Scrolling Routines
 #define WGScroll &SCR
 #define WGScrollBy &SCRBY
-#define WGScrollByX(x) WGScrollBy(x, 0)
-#define WGScrollByY(y) WGScrollBy(0, y)
+#define WGScrollXBy(x) WGScrollBy(x, 0)
+#define WGScrollYBy(y) WGScrollBy(0, y)
+
 
 ' Drawing Routines
-#define WGClearScreen &HOME
-#define WGDesktop &DESK
+#define WGClearScreen &HOME(0)
+#define WGDesktop &HOME(1)
 #define WGPlot &PLOT
 #define WGPrint &PRINT
 #define WGStrokeRect &DRAW

--- a/applesoft.s
+++ b/applesoft.s
@@ -231,6 +231,11 @@ WGAmpersandIntArgument_signed:
 ; Side effects: Clobbers all registers
 WGAmpersandAddrArgument:
 	jsr CHRGOT
+	cmp #TOKEN_GOSUB
+	; if GOSUB token, skip it.
+	bne WGAmpersandAddrArgument_line
+	jsr CHRGET
+WGAmpersandAddrArgument_line:
 	jsr LINGET
 
 	ldx LINNUML

--- a/mddemo.b
+++ b/mddemo.b
@@ -1,0 +1,105 @@
+#include "WeeGUI.h"
+#include <CType.h>
+
+#declare key%
+#pragma optimize 0,2 ' full line optimization in this demo scares applesoft.
+
+#define QuitChar 113
+
+#define TextViewID 0
+#define MainViewID 1
+#define OpenGarageButtonID 2
+#define CloseGarageButtonID 3
+#define ParlorCheckBoxID 4
+#define LoungeCheckBoxID 5
+#define BedroomCheckBoxID 6
+#define QuitButtonID 7
+
+	print chr$(4)"brun weegui"
+	WGDesktop
+	WGCreateView(TextViewID,DecoratedView,2,15,76,7,76,40)
+	WGViewSetTitle("Help")
+	WGViewSetAction(TextViewAction)
+	gosub TextViewAction
+
+	WGFillRect(0,0,80,13,160)
+	WGCreateView(MainViewID,PlainView,1,1,78,11,78,11)
+	WGCreateButton(OpenGarageButtonID,4,3,21,OpenGarageAction,"Open Garage")
+	WGCreateButton(CloseGarageButtonID,4,5,21,CloseGarageAction,"Close Garage")
+
+	WGSelectView(MainViewID)
+	WGSetCursor(40,1)
+	WGPrint(83)
+	WGPrint(83)
+	WGPrint(83)
+	inverse 
+	WGPrint(" Lighting ")
+	normal 
+	WGPrint(83)
+	WGPrint(83)
+	WGPrint(83)
+	WGCreateCheckbox(ParlorCheckBoxID,42,4,"Parlor")
+	WGCreateCheckbox(LoungeCheckBoxID,42,6,"Lounge")
+	WGCreateCheckbox(BedroomCheckBoxID,42,8,"Bedroom")
+	gosub OpenGarageAction
+	WGCreateButton(QuitButtonID,71,1,8,10000,"Quit")
+	WGSelectView(0)
+	WGEnableMouse
+
+	' RUN LOOP
+	repeat
+		WGPendingViewAction
+		WGGet(key%)
+
+		if key% = cUpArrow then 
+			WGSelectView(TextViewID)
+			WGScrollBy(0,1)
+			gosub TextViewAction
+		endif
+		if key% = cDownArrow then 
+			WGSelectView(TextViewID)
+			WGScrollBy(0, - 1)
+			gosub TextViewAction
+		endif
+		if key% = cEscape then 
+			WGViewFocusPrev
+		endif
+		if key% = cTab then 
+			WGViewFocusNext
+		endif
+		if key% = cCR then 
+			WGViewFocusAction
+		endif
+	until key% = QuitChar
+
+	WGDisableMouse
+	WGExit
+	home 
+	end
+
+TextViewAction:
+	WGSelectView(TextViewID)
+	WGEraseViewContents
+	WGSetCursor(2,1)
+	WGPrint("Welcome to the SuperAutoMat6000 home automation system.")
+	WGSetCursor(0,3)
+	WGPrint("Use the buttons and checkboxes above to achieve the perfect mood for any occasion. Frequent use may cause heartburn. Do not look into laser with remaining eye.")
+	WGPrint(" Note that this is a really long, pointless block of meaningless text, but at least you can scroll it!")
+	WGPrint(" Darn good thing too, because it doesn't fit in the allotted space here.")
+	WGSetCursor(8,9)
+	WGPrint("(c)2015 OmniCorp. All rights reserved.")
+	return 
+
+OpenGarageAction:
+	WGSelectView(MainViewID)
+	WGSetCursor(4,8)
+	WGPrint("Garage door is open  ")
+	return
+
+CloseGarageAction:
+	WGSelectView(MainViewID)
+	WGSetCursor(4,8)
+	WGPrint("Garage door is closed")
+	return 
+
+

--- a/mddemo.b
+++ b/mddemo.b
@@ -15,7 +15,7 @@
 #define BedroomCheckBoxID 6
 #define QuitButtonID 7
 
-	print chr$(4)"brun weegui"
+	print "^Dbrun weegui"
 	WGDesktop
 	WGCreateView(TextViewID,DecoratedView,2,15,76,7,76,40)
 	WGViewSetTitle("Help")
@@ -42,7 +42,7 @@
 	WGCreateCheckbox(LoungeCheckBoxID,42,6,"Lounge")
 	WGCreateCheckbox(BedroomCheckBoxID,42,8,"Bedroom")
 	gosub OpenGarageAction
-	WGCreateButton(QuitButtonID,71,1,8,10000,"Quit")
+	WGCreateButton(QuitButtonID,71,1,8,QuitAction,"Quit")
 	WGSelectView(0)
 	WGEnableMouse
 
@@ -72,6 +72,7 @@
 		endif
 	until key% = QuitChar
 
+QuitAction:
 	WGDisableMouse
 	WGExit
 	home 


### PR DESCRIPTION
 Includes header file and MDBasic demo.

Due to MD-BASIC’s design, subroutine references require a `GOSUB` to be recognized as a subroutine (and converted to a line number).  WGAmpersandAddrArgument has been updated to skip over a GOSUB token, if it exists.

